### PR TITLE
Update to newer version of tools.

### DIFF
--- a/projectdata/dependencies.json
+++ b/projectdata/dependencies.json
@@ -3,7 +3,7 @@
 	    "name": "ohNet",
         "type": "openhome",
         "platform-specific": true,
-        "version": "1.0.964",
+        "version": "1.1.1456",
         "archive-suffix": "-${titlecase-debugmode}",
         "configure-args": [
             "--ohnet-lib-dir", "${dest}${name}-${platform}-${titlecase-debugmode}/lib",
@@ -15,19 +15,45 @@
         ]
     },
     {
+	    "name": "ohNetGenerated",
+        "type": "openhome",
+        "platform-specific": true,
+        "version": "1.0.66",
+        "archive-suffix": "-${titlecase-debugmode}",
+        "configure-args": [
+            "--ohnetgenerated-lib-dir", "${dest}${name}-${platform}-${titlecase-debugmode}/lib",
+            "--ohnetgenerated-include-dir", "${dest}${name}-${platform}-${titlecase-debugmode}/include/ohnet"
+        ],
+        "_comment": [
+            "See ohos for more examples, and ohdevtools/dependencies.py for details",
+            "of the predefined values and expansion rules."
+        ]
+    },
+    {
 	    "name": "ohNet-AnyPlatform",
         "type": "openhome",
         "platform-specific": true,
-        "version": "1.0.964",
+        "version": "1.1.1456",
         "archive-suffix": "-Release",
 		"archive-directory": "${binary-repo}/ohNet/",
         "archive-filename": "${archive-prefix}ohNet-${version}-${archive-platform}${archive-suffix}${archive-extension}",
         "dest": "dependencies/AnyPlatform/ohNet",
         "strip-archive-dirs":1
     },
+    {
+	    "name": "ohNetGenerated-AnyPlatform",
+        "type": "openhome",
+        "platform-specific": true,
+        "version": "1.0.66",
+        "archive-suffix": "-Release",
+		"archive-directory": "${binary-repo}/ohNetGenerated/",
+        "archive-filename": "${archive-prefix}ohNetGenerated-${version}-${archive-platform}${archive-suffix}${archive-extension}",
+        "dest": "dependencies/AnyPlatform/ohNetGenerated",
+        "strip-archive-dirs":1
+    },
     {   "name": "ohOs",
         "type": "openhome",
-        "version": "0.2.813",
+        "version": "0.2.824",
         "platform-specific": false,
         "remote-archive-path": "http://openhome.org/releases/artifacts/ohOs2/ohOs2-${version}-AnyPlatform-Release.tar.gz",
         "dest": "dependencies/AnyPlatform/ohOs",
@@ -37,7 +63,7 @@
 	    "name": "ohWafHelpers",
         "type": "openhome",
         "platform-specific": false,
-        "version": "0.0.22",
+        "version": "0.0.70",
         "archive-filename": "${name}-${version}.tar.gz"
     },
 	{

--- a/src/TestSubscription/TestSubscription.csproj
+++ b/src/TestSubscription/TestSubscription.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>x86</PlatformTarget>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -26,6 +27,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -55,8 +57,9 @@
       <Name>ohTopology</Name>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="..\SharedSettings.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/ohTopology/ohTopology.csproj
+++ b/src/ohTopology/ohTopology.csproj
@@ -37,34 +37,34 @@
       <HintPath>..\..\dependencies\nuget\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgInfo1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgInfo1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgInfo1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgMediaServer1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgMediaServer1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgMediaServer1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgPlaylist1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgPlaylist1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgPlaylist1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgProduct1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgProduct1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgProduct1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgRadio1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgRadio1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgRadio1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgReceiver1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgReceiver1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgReceiver1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgSender1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgSender1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgSender1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgTime1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgTime1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgTime1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpAvOpenhomeOrgVolume1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpAvOpenhomeOrgVolume1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpAvOpenhomeOrgVolume1.net.dll</HintPath>
     </Reference>
     <Reference Include="CpUpnpOrgContentDirectory1.net">
-      <HintPath>..\..\dependencies\AnyPlatform\ohNet\lib\CpUpnpOrgContentDirectory1.net.dll</HintPath>
+      <HintPath>..\..\dependencies\AnyPlatform\ohNetGenerated\lib\CpUpnpOrgContentDirectory1.net.dll</HintPath>
     </Reference>
     <Reference Include="ohHttpServer">
       <HintPath>..\..\dependencies\AnyPlatform\ohOs\ohHttpServer.dll</HintPath>

--- a/wscript
+++ b/wscript
@@ -13,9 +13,12 @@ from utilfuncs import invoke_test, guess_dest_platform, configure_toolchain, gue
 
 def options(opt):
     opt.load('msvc')
+    opt.load('compiler_c')
     opt.load('compiler_cxx')
     opt.add_option('--ohnet-include-dir', action='store', default=None)
     opt.add_option('--ohnet-lib-dir', action='store', default=None)
+    opt.add_option('--ohnetgenerated-include-dir', action='store', default=None)
+    opt.add_option('--ohnetgenerated-lib-dir', action='store', default=None)
     opt.add_option('--ohnet', action='store', default=None)
     opt.add_option('--debug', action='store_const', dest="debugmode", const="Debug", default="Release")
     opt.add_option('--release', action='store_const', dest="debugmode",  const="Release", default="Release")
@@ -39,6 +42,7 @@ def configure(conf):
     if conf.options.dest_platform in ['Windows-x86', 'Windows-x64']:
         conf.env.LIB_OHNET=['ws2_32', 'iphlpapi', 'dbghelp']
     conf.env.STLIB_OHNET=['ohNetProxies', 'TestFramework', 'ohNetCore']
+    conf.env.STLIB_OHNETGENERATED=['ohNetGeneratedDevices', 'ohNetGeneratedProxies']
     conf.env.INCLUDES = conf.path.find_node('.').abspath()
 
 def get_node(bld, node_or_filename):
@@ -78,29 +82,29 @@ def build(bld):
                 'OpenHome/Av/CpTopology3.cpp',
                 'OpenHome/Av/CpTopology4.cpp',
             ],
-            use=['OHNET'],
+            use=['OHNET', 'OHNETGENERATED'],
             target='ohTopology')
 
     # Tests
     bld.program(
             source='OpenHome/Av/Tests/TestTopology1.cpp',
-            use=['OHNET', 'ohTopology'],
+            use=['OHNET', 'OHNETGENERATED', 'ohTopology'],
             target='TestTopology1')
     bld.program(
             source='OpenHome/Av/Tests/TestTopology2.cpp',
-            use=['OHNET', 'ohTopology'],
+            use=['OHNET', 'OHNETGENERATED', 'ohTopology'],
             target='TestTopology2')
     bld.program(
             source='OpenHome/Av/Tests/TestTopology3.cpp',
-            use=['OHNET', 'ohTopology'],
+            use=['OHNET', 'OHNETGENERATED', 'ohTopology'],
             target='TestTopology3')
     bld.program(
             source='OpenHome/Av/Tests/TestTopology4.cpp',
-            use=['OHNET', 'ohTopology'],
+            use=['OHNET', 'OHNETGENERATED', 'ohTopology'],
             target='TestTopology4')
     bld.program(
             source='OpenHome/Av/Tests/TestTopology.cpp',
-            use=['OHNET', 'ohTopology'],
+            use=['OHNET', 'OHNETGENERATED', 'ohTopology'],
             target='TestTopology')
 
     # Bundles


### PR DESCRIPTION
In its current configuration ohTopology can't be easily build. My patch allows it to be build without changing source files (providing you have a patched ohWafHelpers).
