### PR TITLE
wscript needs Python2

### DIFF
--- a/wscript
+++ b/wscript
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-
+#!/usr/bin/python2
 import sys
 import os
 


### PR DESCRIPTION
By setting the shebang to `python2` the correct Python interpreter will be used on modern systems where `python` is a symlink to `python3`.